### PR TITLE
Update broken link

### DIFF
--- a/deploy-guide/source/provisioning/root_device.rst
+++ b/deploy-guide/source/provisioning/root_device.rst
@@ -103,4 +103,4 @@ with the Mitaka release. Also note that the ``name`` field, while convenient,
 
 Do not forget to re-run the introspection after setting the root device hints.
 
-.. _Ironic root device hints documentation: https://docs.openstack.org/ironic/deploy/install-guide.html#specifying-the-disk-for-deployment
+.. _Ironic root device hints documentation: https://docs.openstack.org/ironic/latest/install/advanced.html#specifying-the-disk-for-deployment-root-device-hints


### PR DESCRIPTION
This fixes the link against ' Ironic root device hints documentation' for 'Specifying the disk deployment' in the documentation of TripleO. [Link](https://docs.openstack.org/project-deploy-guide/tripleo-docs/latest/provisioning/root_device.html) to the page of broken link.